### PR TITLE
fix: Copy Cargo.lock from tgi to respect pinned versions

### DIFF
--- a/huggingface/pytorch/tgi/docker/1.4.0/Dockerfile
+++ b/huggingface/pytorch/tgi/docker/1.4.0/Dockerfile
@@ -1,11 +1,13 @@
 # Rust builder
-FROM lukemathwalker/cargo-chef:latest-rust-1.71 AS chef
+# https://hub.docker.com/r/lukemathwalker/cargo-chef/tags?page=1&name=latest-rust-1.75
+FROM lukemathwalker/cargo-chef:latest-rust-1.75 AS chef
 WORKDIR /usr/src
 
 ARG CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
 
 FROM chef as planner
 COPY Cargo.toml Cargo.toml
+COPY Cargo.lock Cargo.lock
 COPY rust-toolchain.toml rust-toolchain.toml
 COPY proto proto
 COPY benchmark benchmark
@@ -28,6 +30,7 @@ COPY --from=planner /usr/src/recipe.json recipe.json
 RUN cargo chef cook --release --recipe-path recipe.json
 
 COPY Cargo.toml Cargo.toml
+COPY Cargo.lock Cargo.lock
 COPY rust-toolchain.toml rust-toolchain.toml
 COPY proto proto
 COPY benchmark benchmark

--- a/huggingface/pytorch/tgi/docker/1.4.0/Dockerfile
+++ b/huggingface/pytorch/tgi/docker/1.4.0/Dockerfile
@@ -1,6 +1,5 @@
 # Rust builder
-# https://hub.docker.com/r/lukemathwalker/cargo-chef/tags?page=1&name=latest-rust-1.75
-FROM lukemathwalker/cargo-chef:latest-rust-1.75 AS chef
+FROM lukemathwalker/cargo-chef:latest-rust-1.71 AS chef
 WORKDIR /usr/src
 
 ARG CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse


### PR DESCRIPTION
…stc 1.74 or newer, while the currently active rustc version is 1.71.1

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
