### PR TITLE
fix: Upgrading libgssapi-krb5-2

### DIFF
--- a/huggingface/pytorch/optimum/docker/0.0.23/Dockerfile
+++ b/huggingface/pytorch/optimum/docker/0.0.23/Dockerfile
@@ -78,6 +78,7 @@ FROM base AS neuron
 # Install system prerequisites
 RUN apt-get update -y \
     && apt-get install -y --no-install-recommends \
+    libgssapi-krb5-2
     gnupg2 \
     wget \
     python3-dev \

--- a/huggingface/pytorch/optimum/docker/0.0.23/Dockerfile
+++ b/huggingface/pytorch/optimum/docker/0.0.23/Dockerfile
@@ -78,7 +78,6 @@ FROM base AS neuron
 # Install system prerequisites
 RUN apt-get update -y \
     && apt-get install -y --no-install-recommends \
-    libgssapi-krb5-2
     gnupg2 \
     wget \
     python3-dev \

--- a/huggingface/pytorch/tgi/docker/2.2.0/Dockerfile
+++ b/huggingface/pytorch/tgi/docker/2.2.0/Dockerfile
@@ -51,6 +51,7 @@ ARG TARGETPLATFORM
 ENV PATH /opt/conda/bin:$PATH
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    libgssapi-krb5-2 \
     build-essential \
     ca-certificates \
     ccache \


### PR DESCRIPTION
Upgrading `libgssapi-krb5-2`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
