### PR TITLE
Update release.json file to patch TGI 2.2.0 

### DIFF
--- a/huggingface/pytorch/tgi/docker/2.2.0/Dockerfile
+++ b/huggingface/pytorch/tgi/docker/2.2.0/Dockerfile
@@ -56,7 +56,6 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
     ca-certificates \
     ccache \
     curl \
-    libgssapi-krb5-2 \
     git && \
     rm -rf /var/lib/apt/lists/*
 

--- a/huggingface/pytorch/tgi/docker/2.2.0/Dockerfile
+++ b/huggingface/pytorch/tgi/docker/2.2.0/Dockerfile
@@ -50,7 +50,7 @@ ARG TARGETPLATFORM
 
 ENV PATH /opt/conda/bin:$PATH
 
-RUN apt-get update && apt-get upgrade && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get upgrade -y && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     build-essential \
     ca-certificates \
     ccache \

--- a/huggingface/pytorch/tgi/docker/2.2.0/Dockerfile
+++ b/huggingface/pytorch/tgi/docker/2.2.0/Dockerfile
@@ -55,11 +55,11 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
     ca-certificates \
     ccache \
     curl \
-    git && \
-    apt-get upgrade libgssapi-krb5-2 \
+    libgssapi-krb5-2 \
     libk5crypto3 \
     libkrb5support0 \
-    libkrb5-3 && \
+    libkrb5-3 \
+    git && \
     rm -rf /var/lib/apt/lists/*
 
 # Install conda

--- a/huggingface/pytorch/tgi/docker/2.2.0/Dockerfile
+++ b/huggingface/pytorch/tgi/docker/2.2.0/Dockerfile
@@ -56,6 +56,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
     ca-certificates \
     ccache \
     curl \
+    libgssapi-krb5-2 \
     git && \
     rm -rf /var/lib/apt/lists/*
 

--- a/huggingface/pytorch/tgi/docker/2.2.0/Dockerfile
+++ b/huggingface/pytorch/tgi/docker/2.2.0/Dockerfile
@@ -55,8 +55,8 @@ RUN apt-get update && apt-get upgrade -y && DEBIAN_FRONTEND=noninteractive apt-g
     ca-certificates \
     ccache \
     curl \
-    libgssapi-krb5-2 \
-    libk5crypto3 \
+    libgssapi-krb5-2=1.19.2-2ubuntu0.4 \
+    libk5crypto3=1.19.2-2ubuntu0.4 \
     libkrb5support0 \
     libkrb5-3 \
     git && \

--- a/huggingface/pytorch/tgi/docker/2.2.0/Dockerfile
+++ b/huggingface/pytorch/tgi/docker/2.2.0/Dockerfile
@@ -51,12 +51,15 @@ ARG TARGETPLATFORM
 ENV PATH /opt/conda/bin:$PATH
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    libgssapi-krb5-2 \
     build-essential \
     ca-certificates \
     ccache \
     curl \
     git && \
+    apt-get upgrade libgssapi-krb5-2 \
+    libk5crypto3 \
+    libkrb5support0 \
+    libkrb5-3 && \
     rm -rf /var/lib/apt/lists/*
 
 # Install conda

--- a/huggingface/pytorch/tgi/docker/2.2.0/Dockerfile
+++ b/huggingface/pytorch/tgi/docker/2.2.0/Dockerfile
@@ -50,7 +50,7 @@ ARG TARGETPLATFORM
 
 ENV PATH /opt/conda/bin:$PATH
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get upgrade && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     build-essential \
     ca-certificates \
     ccache \

--- a/releases.json
+++ b/releases.json
@@ -79,11 +79,12 @@
     "releases": [
         {
             "framework": "TGI",
-            "device": "inf2",
-            "version": "0.0.24",
+            "device": "gpu",
+            "version": "2.2.0",
             "os_version": "ubuntu22.04",
+            "cuda_version": "cu121",
             "python_version": "py310",
-            "pytorch_version": "2.1.2"
+            "pytorch_version": "2.3.0"
         }
     ]
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Patch TGI 2.2.0 image for vulnerability libgssapi-krb5-2


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
