### PR TITLE
Update libgssapi-krb5-2 gpu for tei

### DIFF
--- a/huggingface/pytorch/tei/docker/1.4.0/gpu/Dockerfile
+++ b/huggingface/pytorch/tei/docker/1.4.0/gpu/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
     curl \
     libssl-dev \
     pkg-config \
+    libgssapi-krb5-2 \
     && rm -rf /var/lib/apt/lists/*
 
 # Donwload and configure sccache

--- a/releases.json
+++ b/releases.json
@@ -58,7 +58,7 @@
             {
                 "device": "gpu",
                 "min_version": "1.2.1",
-                "max_version": "1.4.0",
+                "max_version": "1.5.0",
                 "os_version": "ubuntu22.04",
                 "cuda_version": "cu122",
                 "python_version": "py310",
@@ -78,12 +78,12 @@
     "ignore_vulnerabilities": ["CVE-2024-42154 - linux"],
     "releases": [
         {
-            "framework": "TGI",
-            "device": "inf2",
-            "version": "0.0.24",
+            "framework": "TEI",
+            "device": "gpu",
+            "version": "1.5.0",
             "os_version": "ubuntu22.04",
             "python_version": "py310",
-            "pytorch_version": "2.1.2"
+            "pytorch_version": "2.0.1"
         }
     ]
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add libgssapi-krb5-2 to apt-get in gpu dockerfile to update the dependency to patch CVE

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
