### PR TITLE
Patch linux-lib-dev on tgi 2.4.0

### DIFF
--- a/huggingface/pytorch/tgi/docker/2.4.0/Dockerfile
+++ b/huggingface/pytorch/tgi/docker/2.4.0/Dockerfile
@@ -208,6 +208,7 @@ RUN apt-get update && apt-get upgrade -y && DEBIAN_FRONTEND=noninteractive apt-g
     git \
     libexpat1 \
     libgssapi-krb5-2 \
+    linux-libc-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy conda with PyTorch installed

--- a/releases.json
+++ b/releases.json
@@ -90,11 +90,12 @@
     "releases": [
         {
             "framework": "TGI",
-            "device": "inf2",
-            "version": "0.0.27",
+            "device": "gpu",
+            "version": "2.4.0",
             "os_version": "ubuntu22.04",
-            "python_version": "py310",
-            "pytorch_version": "2.1.2"
+            "cuda_version": "cu124",
+            "python_version": "py311",
+            "pytorch_version": "2.4.0"
         }
     ]
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
 CVE for linux-libc-dev 5.15.0 detected. This updates the dependency version to patch the vulnerability

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
