### PR TITLE
Move linux-libc-dev patch lower for tgi 2.4.0 to avoid CVE patch being overwritten

### DIFF
--- a/huggingface/pytorch/tgi/docker/2.4.0/Dockerfile
+++ b/huggingface/pytorch/tgi/docker/2.4.0/Dockerfile
@@ -208,7 +208,6 @@ RUN apt-get update && apt-get upgrade -y && DEBIAN_FRONTEND=noninteractive apt-g
     git \
     libexpat1 \
     libgssapi-krb5-2 \
-    linux-libc-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy conda with PyTorch installed
@@ -267,6 +266,7 @@ ENV EXLLAMA_NO_FLASH_ATTN=1
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     build-essential \
     g++ \
+    linux-libc-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Install benchmarker


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
