### PR TITLE
Removed the build optimization in buildspec.yml

### DIFF
--- a/huggingface/pytorch/tei/docker/buildspec.yml
+++ b/huggingface/pytorch/tei/docker/buildspec.yml
@@ -3,7 +3,7 @@ version: 0.2
 env:
   shell: bash
   variables:
-    FRAMEWORK_FOLDER: "huggingface/pytorch/tei/docker"
+    FRAMEWORK_FOLDER: "huggingface/pytorch"
     PYTHONPATH: "/codebuild/output/src*/src/github.com/awslabs/llm-hosting-container"
 
 phases:

--- a/huggingface/pytorch/tgi/docker/buildspec.yml
+++ b/huggingface/pytorch/tgi/docker/buildspec.yml
@@ -3,7 +3,7 @@ version: 0.2
 env:
   shell: bash
   variables:
-    FRAMEWORK_FOLDER: "huggingface/pytorch/tgi/docker"
+    FRAMEWORK_FOLDER: "huggingface/pytorch"
     PYTHONPATH: "/codebuild/output/src*/src/github.com/awslabs/llm-hosting-container"
 
 phases:

--- a/huggingface/pytorch/tgillamacpp/docker/buildspec.yml
+++ b/huggingface/pytorch/tgillamacpp/docker/buildspec.yml
@@ -4,7 +4,7 @@ version: 0.2
 env:
   shell: bash
   variables:
-    FRAMEWORK_FOLDER: "huggingface/pytorch/tgi-llamacpp/docker"
+    FRAMEWORK_FOLDER: "huggingface/pytorch"
     PYTHONPATH: "/codebuild/output/src*/src/github.com/awslabs/llm-hosting-container"
 
 phases:

--- a/releases.json
+++ b/releases.json
@@ -108,12 +108,11 @@
     "releases": [
         {
             "framework": "TGI",
-            "device": "gpu",
-            "version": "3.1.1",
+            "device": "inf2",
+            "version": "0.0.28",
             "os_version": "ubuntu22.04",
-            "cuda_version": "cu124",
-            "python_version": "py311",
-            "pytorch_version": "2.6.0"
+            "python_version": "py310",
+            "pytorch_version": "2.1.2"
         }
     ]
 }

--- a/releases.json
+++ b/releases.json
@@ -108,11 +108,12 @@
     "releases": [
         {
             "framework": "TGI",
-            "device": "inf2",
-            "version": "0.0.28",
+            "device": "gpu",
+            "version": "3.1.1",
             "os_version": "ubuntu22.04",
-            "python_version": "py310",
-            "pytorch_version": "2.1.2"
+            "cuda_version": "cu124",
+            "python_version": "py311",
+            "pytorch_version": "2.6.0"
         }
     ]
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Due to build optimization, this [PR](https://github.com/awslabs/llm-hosting-container/pull/130) skipped the build of the the image in the PR hook codeBuild. So for now we decided to remove this extra optimization.
- Removed the build optimization in buildspec.yml.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
