### PR TITLE
patch libgssapi-krb5-2

### DIFF
--- a/huggingface/pytorch/tei/docker/1.6.0/gpu/Dockerfile
+++ b/huggingface/pytorch/tei/docker/1.6.0/gpu/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get upgrade -y && DEBIAN_FRONTEND=noninteractive apt-g
     curl \
     libssl-dev \
     pkg-config \
+    libgssapi-krb5-2 \
     && rm -rf /var/lib/apt/lists/*
 
 # Donwload and configure sccache


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Releases.json already set for this image, no need to update. Patching libgssapi-krb5-2

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
