### PR TITLE
Update default HUGGINGFACE_HUB_CACHE env variable in TEI

### DIFF
--- a/huggingface/pytorch/tei/docker/1.7.0/cpu/Dockerfile
+++ b/huggingface/pytorch/tei/docker/1.7.0/cpu/Dockerfile
@@ -74,7 +74,7 @@ RUN --mount=type=secret,id=actions_cache_url,env=ACTIONS_CACHE_URL \
 
 FROM debian:bookworm-slim AS base
 
-ENV HUGGINGFACE_HUB_CACHE=/data \
+ENV HUGGINGFACE_HUB_CACHE=/opt/ml/model \
     PORT=80 \
     HF_HUB_USER_AGENT_ORIGIN=aws:sagemaker:cpu:inference:tei \
     MKL_ENABLE_INSTRUCTIONS=AVX512_E4 \

--- a/huggingface/pytorch/tei/docker/1.7.0/gpu/Dockerfile
+++ b/huggingface/pytorch/tei/docker/1.7.0/gpu/Dockerfile
@@ -95,7 +95,7 @@ FROM nvidia/cuda:12.2.0-runtime-ubuntu22.04 AS base
 
 ARG DEFAULT_USE_FLASH_ATTENTION=True
 
-ENV HUGGINGFACE_HUB_CACHE=/data \
+ENV HUGGINGFACE_HUB_CACHE=/opt/ml/model \
     PORT=80 \
     USE_FLASH_ATTENTION=$DEFAULT_USE_FLASH_ATTENTION \
     HF_HUB_USER_AGENT_ORIGIN=aws:sagemaker:gpu-cuda:inference:tei


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Updating the default hub cache environment variable in order to resolve https://github.com/huggingface/text-embeddings-inference/issues/609

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
