### PR TITLE
Add TGI 3.3.4 Neuron image

### DIFF
--- a/huggingface/pytorch/optimum/docker/3.3.4/Dockerfile
+++ b/huggingface/pytorch/optimum/docker/3.3.4/Dockerfile
@@ -1,0 +1,60 @@
+FROM ghcr.io/huggingface/text-generation-inference:3.3.4-neuron AS base
+
+# The target image for the automated build has to be called sagemaker
+FROM base AS sagemaker
+
+# This is required to properly track hub usage metrics
+ENV HF_HUB_USER_AGENT_ORIGIN="aws:sagemaker:neuron:inference:tgi-optimum-neuron"
+
+# Create the entrypoint script
+# We use a 'heredoc' pattern to keep the Dockerfile self-contained
+# All content within the 'EOF' marker is written to the entrypoint.sh file
+RUN cat <<'EOF' > entrypoint.sh
+#!/bin/bash
+
+if [[ -z "${HF_MODEL_ID}" ]]; then
+  echo "HF_MODEL_ID must be set"
+  exit 1
+fi
+export MODEL_ID="${HF_MODEL_ID}"
+
+if [[ -n "${HF_MODEL_REVISION}" ]]; then
+  export REVISION="${HF_MODEL_REVISION}"
+fi
+
+if [[ -z "${MAX_BATCH_SIZE}" ]]; then
+  echo "MAX_BATCH_SIZE must be set to the model static batch size"
+  exit 1
+fi
+
+text-generation-launcher --port 8080
+EOF
+# Make the generated entrypoint script executable
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["./entrypoint.sh"]
+
+RUN apt-get update && apt-get install -y --no-install-recommends curl unzip \
+    && rm -rf /var/lib/apt/lists/*
+RUN HOME_DIR=/root && \
+    pip install requests && \
+    curl -o ${HOME_DIR}/oss_compliance.zip https://aws-dlinfra-utilities.s3.amazonaws.com/oss_compliance.zip && \
+    unzip ${HOME_DIR}/oss_compliance.zip -d ${HOME_DIR}/ && \
+    cp ${HOME_DIR}/oss_compliance/test/testOSSCompliance /usr/local/bin/testOSSCompliance && \
+    chmod +x /usr/local/bin/testOSSCompliance && \
+    chmod +x ${HOME_DIR}/oss_compliance/generate_oss_compliance.sh && \
+    ${HOME_DIR}/oss_compliance/generate_oss_compliance.sh ${HOME_DIR} python && \
+    rm -rf ${HOME_DIR}/oss_compliance*
+
+RUN echo "N.B.: Although this image is released under the Apache-2.0 License, the Dockerfile used to build the image \
+    has an indirect documentation dependency on third party <docutils/tools/editors/emacs/rst.el> project. The \
+    <docutils/tools/editors/emacs/rst.el> project's licensing includes the <GPL v3> license. \
+    \n\n\
+    N.B.: Although this image is released under the Apache-2.0 License, the Dockerfile used to build the image uses the \
+    third party <Text Generation Inference (TGI)> project. The <Text Generation Inference (TGI)> project's licensing \
+    includes the <HFOIL --> https://github.com/huggingface/text-generation-inference/blob/main/LICENSE> \
+    license." > /root/THIRD_PARTY_LICENSES
+
+LABEL dlc_major_version="1"
+LABEL com.amazonaws.ml.engines.sagemaker.dlc.framework.huggingface.tgi="true"
+LABEL com.amazonaws.sagemaker.capabilities.accept-bind-to-port="true"

--- a/releases.json
+++ b/releases.json
@@ -79,6 +79,14 @@
                 "os_version": "ubuntu22.04",
                 "python_version": "py310",
                 "pytorch_version": "2.1.2"
+            },
+            {
+                "device": "inf2",
+                "min_version": "3.2.0",
+                "max_version": "3.2.0",
+                "os_version": "ubuntu22.04",
+                "python_version": "py310",
+                "pytorch_version": "2.5.1"
             }
         ],
         "TEI": [

--- a/releases.json
+++ b/releases.json
@@ -82,8 +82,8 @@
             },
             {
                 "device": "inf2",
-                "min_version": "3.2.0",
-                "max_version": "3.2.0",
+                "min_version": "3.3.4",
+                "max_version": "3.3.4",
                 "os_version": "ubuntu22.04",
                 "python_version": "py310",
                 "pytorch_version": "2.5.1"
@@ -116,29 +116,12 @@
     ],
     "releases": [
         {
-            "framework": "TEI",
-            "device": "gpu",
-            "version": "1.7.0",
-            "os_version": "ubuntu22.04",
-            "python_version": "py310",
-            "pytorch_version": "2.0.1",
-            "cuda_version": "cu122"
-        },
-        {
-            "framework": "TEI",
-            "device": "cpu",
-            "version": "1.7.0",
-            "os_version": "ubuntu22.04",
-            "python_version": "py310",
-            "pytorch_version": "2.0.1"
-        },
-        {
             "framework": "TGI",
             "device": "inf2",
-            "version": "0.0.28",
+            "version": "3.3.4",
             "os_version": "ubuntu22.04",
             "python_version": "py310",
-            "pytorch_version": "2.1.2"
+            "pytorch_version": "2.5.1"
         }
     ]
 }

--- a/tests/huggingface/sagemaker_dlc_test.py
+++ b/tests/huggingface/sagemaker_dlc_test.py
@@ -26,7 +26,7 @@ def run_test(args):
         default_env["HF_MODEL_REVISION"] = args.model_revision
     if args.instance_type.startswith("ml.inf2"):
         default_env["HF_NUM_CORES"] = "2"
-        default_env["HF_AUTO_CAST_TYPE"] = "fp16"
+        default_env["HF_AUTO_CAST_TYPE"] = "bf16"
         default_env["MAX_BATCH_SIZE"] = "1"
         default_env["MAX_INPUT_TOKENS"] = "2048"
         default_env["MAX_TOTAL_TOKENS"] = "4096"
@@ -81,7 +81,7 @@ def get_models_for_image(image_type, device_type):
                 ("google/flan-t5-xxl", None, "ml.g5.12xlarge"),
             ]
         elif device_type == "inf2":
-            return [ ("princeton-nlp/Sheared-LLaMA-1.3B", None, "ml.inf2.xlarge") ]
+            return [ ("Qwen/Qwen2.5-0.5B", None, "ml.inf2.8xlarge") ]
         else:
             raise ValueError(f"No testing models found for {image_type} on instance {device_type}. "
                              f"please check whether the image_type and instance_type are supported.")


### PR DESCRIPTION
This adds the container for TGI Neuron 3.3.4.

The main changes are:

- uses AWS Neuron SDK 2.22.0,
- uses pytorch 2.5.1,
- adds support for phi models (including microsoft/phi4),
- now aligns on TGI version numbers.
