### PR TITLE
Update HF sagemaker DLC test to use a Neuron Inference AMI version on inf2

### DIFF
--- a/tests/huggingface/sagemaker_dlc_test.py
+++ b/tests/huggingface/sagemaker_dlc_test.py
@@ -54,6 +54,7 @@ def run_test(args):
         }
         if args.instance_type.startswith("ml.inf2"):
             deploy_parameters["volume_size"] = 256
+            deploy_parameters["inference_ami_version"] = "al2-ami-sagemaker-inference-neuron-2"
         predictor = model.deploy(**deploy_parameters)
 
         logging.info("Endpoint deployment complete.")


### PR DESCRIPTION
Update huggingface/sagemaker_dlc_test.py to use a Neuron inference_ami_version on inf2

*Issue #, if available:*
N/A

*Description of changes:*

Update tests/huggingface/sagemaker_dlc_test.py to use inference_ami_version `al2-ami-sagemaker-inference-neuron-2` for tests run on inf2 instances. This is because without the ami version, tests on inf2 were using Neuron Driver 2.10, which is very outdated and was causing HuggingFace tests to fail.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
