### PR TITLE
TGI 3.3.6 Neuron Image

### DIFF
--- a/huggingface/pytorch/optimum/docker/3.3.6/Dockerfile
+++ b/huggingface/pytorch/optimum/docker/3.3.6/Dockerfile
@@ -1,0 +1,32 @@
+FROM ghcr.io/huggingface/text-generation-inference:3.3.6-neuron AS base
+
+# The target image for the automated build has to be called sagemaker
+FROM base AS sagemaker
+
+# This is required to properly track hub usage metrics
+ENV HF_HUB_USER_AGENT_ORIGIN="aws:sagemaker:neuron:inference:tgi-optimum-neuron"
+
+# Launch original TGI neuron entrypoint, but with port 8080
+ENTRYPOINT ["./tgi-entrypoint.sh", "--port", "8080"]
+
+RUN apt-get update \
+    && apt-get upgrade -y linux-libc-dev \
+    && apt-get install -y --no-install-recommends curl unzip libsqlite3-0 libxml2 \
+    && rm -rf /var/lib/apt/lists/*
+RUN HOME_DIR=/root && \
+    pip install requests && \
+    curl -o ${HOME_DIR}/oss_compliance.zip https://aws-dlinfra-utilities.s3.amazonaws.com/oss_compliance.zip && \
+    unzip ${HOME_DIR}/oss_compliance.zip -d ${HOME_DIR}/ && \
+    cp ${HOME_DIR}/oss_compliance/test/testOSSCompliance /usr/local/bin/testOSSCompliance && \
+    chmod +x /usr/local/bin/testOSSCompliance && \
+    chmod +x ${HOME_DIR}/oss_compliance/generate_oss_compliance.sh && \
+    ${HOME_DIR}/oss_compliance/generate_oss_compliance.sh ${HOME_DIR} python && \
+    rm -rf ${HOME_DIR}/oss_compliance*
+
+RUN echo "N.B.: Although this image is released under the Apache-2.0 License, the Dockerfile used to build the image \
+    has an indirect documentation dependency on third party <docutils/tools/editors/emacs/rst.el> project. The \
+    <docutils/tools/editors/emacs/rst.el> project's licensing includes the <GPL v3> license." > /root/THIRD_PARTY_LICENSES
+
+LABEL dlc_major_version="1"
+LABEL com.amazonaws.ml.engines.sagemaker.dlc.framework.huggingface.tgi="true"
+LABEL com.amazonaws.sagemaker.capabilities.accept-bind-to-port="true"

--- a/releases.json
+++ b/releases.json
@@ -96,6 +96,14 @@
                 "os_version": "ubuntu22.04",
                 "python_version": "py310",
                 "pytorch_version": "2.5.1"
+            },
+            {
+                "device": "inf2",
+                "min_version": "3.3.6",
+                "max_version": "3.3.6",
+                "os_version": "ubuntu22.04",
+                "python_version": "py310",
+                "pytorch_version": "2.7.0"
             }
         ],
         "TEI": [
@@ -144,10 +152,10 @@
         {
             "framework": "TGI",
             "device": "inf2",
-            "version": "3.3.4",
+            "version": "3.3.6",
             "os_version": "ubuntu22.04",
             "python_version": "py310",
-            "pytorch_version": "2.5.1"
+            "pytorch_version": "2.7.0"
         },
         {
             "framework": "TGI",

--- a/tests/huggingface/sagemaker_dlc_test.py
+++ b/tests/huggingface/sagemaker_dlc_test.py
@@ -82,7 +82,7 @@ def get_models_for_image(image_type, device_type):
                 ("google/flan-t5-xxl", None, "ml.g5.12xlarge"),
             ]
         elif device_type == "inf2":
-            return [ ("Qwen/Qwen2.5-0.5B", None, "ml.inf2.8xlarge") ]
+            return [ ("Qwen/Qwen3-0.6B", None, "ml.inf2.8xlarge") ]
         else:
             raise ValueError(f"No testing models found for {image_type} on instance {device_type}. "
                              f"please check whether the image_type and instance_type are supported.")


### PR DESCRIPTION
This adds the container for TGI Neuron 3.3.6.

The main changes are:

    uses AWS Neuron SDK 2.23.0,
    uses pytorch 2.7.0,
    adds support for qwen3 models,
    updated TGI version.

