### PR TITLE
Pin SageMaker version to < 3.0.0 in requirements files

### DIFF
--- a/huggingface/pytorch/tei/docker/tei-requirements.txt
+++ b/huggingface/pytorch/tei/docker/tei-requirements.txt
@@ -2,7 +2,7 @@ boto3
 dataclasses
 docker
 gitpython
-sagemaker
+sagemaker<3.0.0
 
 parameterized
 pytest

--- a/huggingface/pytorch/tgi/docker/tgi-requirements.txt
+++ b/huggingface/pytorch/tgi/docker/tgi-requirements.txt
@@ -2,7 +2,7 @@ boto3
 dataclasses
 docker
 gitpython
-sagemaker
+sagemaker<3.0.0
 
 parameterized
 pytest

--- a/huggingface/pytorch/tgillamacpp/docker/tgi-llamacpp-requirements.txt
+++ b/huggingface/pytorch/tgillamacpp/docker/tgi-llamacpp-requirements.txt
@@ -2,7 +2,7 @@ boto3
 dataclasses
 docker
 gitpython
-sagemaker
+sagemaker<3.0.0
 
 parameterized
 pytest


### PR DESCRIPTION
*Description of changes:*

This PR pins `sagemaker-python-sdk` verision to `<3.0.0` across all Hugging Face `requirements.txt` files to prevent incompatibility issues.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
