### PR TITLE
chore: update ignore_vulnerabilities list with additional CVEs

### DIFF
--- a/releases.json
+++ b/releases.json
@@ -129,7 +129,9 @@
     "ignore_vulnerabilities": [
         "CVE-2024-42154 - linux",
         "CVE-2025-32434 - torch",
-        "CVE-2024-48063 - torch"
+        "CVE-2024-48063 - torch",
+        "CVE-2025-69872 - diskcache",
+        "CVE-2026-34520 — aiohttp"
     ],
     "releases": [
         {


### PR DESCRIPTION
*Description of changes:*

Ignored 2 additional vulnerabilities:
- CVE-2025-69872 - diskcache: No fix available.
- CVE-2026-34520 - aiohttp: Low risk, TGI in maintenance mode

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
