### PR TITLE
Restore TEI 1.8.2 release entries in releases.json

### DIFF
--- a/releases.json
+++ b/releases.json
@@ -148,6 +148,23 @@
             "os_version": "ubuntu22.04",
             "python_version": "py310",
             "pytorch_version": "2.7.0"
+        },
+        {
+            "framework": "TEI",
+            "device": "gpu",
+            "version": "1.8.2",
+            "os_version": "ubuntu22.04",
+            "cuda_version": "cu122",
+            "python_version": "py310",
+            "pytorch_version": "2.0.1"
+        },
+        {
+            "framework": "TEI",
+            "device": "cpu",
+            "version": "1.8.2",
+            "os_version": "ubuntu22.04",
+            "python_version": "py310",
+            "pytorch_version": "2.0.1"
         }
     ]
 }


### PR DESCRIPTION
TEI GPU and CPU release entries were accidentally removed in #180 (TGI 3.3.6 update). This restores them so TEI builds produce images.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
