### PR TITLE
test: validate PR workflow after docker login removal

### DIFF
--- a/huggingface/pytorch/tgi/docker/buildspec.yml
+++ b/huggingface/pytorch/tgi/docker/buildspec.yml
@@ -44,4 +44,4 @@ phases:
   post_build:
     commands:
       - |
-        echo Build completed on `date`
+        echo "Build completed on $(date)"


### PR DESCRIPTION
## Summary
- Trivial buildspec change to validate PR CodeBuild workflows still function after docker login removal (#190)
- Will close after confirming builds pass

## Test plan
- [ ] PR CodeBuild job triggers successfully
- [ ] Build completes without docker login errors