### PR TITLE
Add `huggingface/pytorch/tei/docker/1.9.3`

### DIFF
--- a/huggingface/pytorch/tei/docker/1.9.3/cpu/Dockerfile
+++ b/huggingface/pytorch/tei/docker/1.9.3/cpu/Dockerfile
@@ -95,4 +95,3 @@ ENV HF_HUB_USER_AGENT_ORIGIN=aws:sagemaker:cpu:inference:tei
 
 COPY --chmod=775 /huggingface/pytorch/tei/docker/1.9.3/cpu/entrypoint.sh entrypoint.sh
 ENTRYPOINT ["./entrypoint.sh"]
-CMD ["--json-output"]

--- a/huggingface/pytorch/tei/docker/1.9.3/cpu/Dockerfile
+++ b/huggingface/pytorch/tei/docker/1.9.3/cpu/Dockerfile
@@ -1,0 +1,98 @@
+FROM lukemathwalker/cargo-chef:latest-rust-1.92-bookworm AS chef
+WORKDIR /usr/src
+
+ENV SCCACHE=0.10.0
+ENV RUSTC_WRAPPER=/usr/local/bin/sccache
+
+# Donwload, configure sccache
+RUN curl -fsSL https://github.com/mozilla/sccache/releases/download/v$SCCACHE/sccache-v$SCCACHE-x86_64-unknown-linux-musl.tar.gz | tar -xzv --strip-components=1 -C /usr/local/bin sccache-v$SCCACHE-x86_64-unknown-linux-musl/sccache && \
+    chmod +x /usr/local/bin/sccache
+
+FROM chef AS planner
+
+COPY backends backends
+COPY core core
+COPY router router
+COPY Cargo.toml ./
+COPY Cargo.lock ./
+
+RUN cargo chef prepare  --recipe-path recipe.json
+
+FROM chef AS builder
+
+ARG GIT_SHA
+ARG DOCKER_LABEL
+
+# sccache specific variables
+ARG SCCACHE_GHA_ENABLED
+
+RUN apt-get update && DEBIAN_FRONTEND=nointeractive apt-get install -y --no-install-recommends \
+    ca-certificates \
+    wget \
+    gnupg \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB \
+    | gpg --dearmor | tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null && \
+    echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | \
+    tee /etc/apt/sources.list.d/oneAPI.list
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    intel-oneapi-mkl-devel=2024.0.0-49656 \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN echo "int mkl_serv_intel_cpu_true() {return 1;}" > fakeintel.c && \
+    gcc -shared -fPIC -o libfakeintel.so fakeintel.c
+
+COPY --from=planner /usr/src/recipe.json recipe.json
+
+RUN --mount=type=secret,id=actions_results_url,env=ACTIONS_RESULTS_URL \
+    --mount=type=secret,id=actions_runtime_token,env=ACTIONS_RUNTIME_TOKEN \
+    cargo chef cook --release --features ort,candle,mkl,static-linking --no-default-features --recipe-path recipe.json && sccache -s
+
+COPY backends backends
+COPY core core
+COPY router router
+COPY Cargo.toml ./
+COPY Cargo.lock ./
+
+RUN --mount=type=secret,id=actions_results_url,env=ACTIONS_RESULTS_URL \
+    --mount=type=secret,id=actions_runtime_token,env=ACTIONS_RUNTIME_TOKEN \
+    cargo build --release --bin text-embeddings-router --features ort,candle,mkl,static-linking,http --no-default-features && sccache -s
+
+FROM debian:bookworm-slim AS base
+
+ENV HUGGINGFACE_HUB_CACHE=/opt/ml/model \
+    PORT=8080 \
+    MKL_ENABLE_INSTRUCTIONS=AVX512_E4 \
+    RAYON_NUM_THREADS=8 \
+    LD_PRELOAD=/usr/local/libfakeintel.so \
+    LD_LIBRARY_PATH=/usr/local/lib
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    libomp-dev \
+    ca-certificates \
+    libssl-dev \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy a lot of the Intel shared objects because of the mkl_serv_intel_cpu_true patch...
+COPY --from=builder /opt/intel/oneapi/mkl/latest/lib/intel64/libmkl_intel_lp64.so.2 /usr/local/lib/libmkl_intel_lp64.so.2
+COPY --from=builder /opt/intel/oneapi/mkl/latest/lib/intel64/libmkl_intel_thread.so.2 /usr/local/lib/libmkl_intel_thread.so.2
+COPY --from=builder /opt/intel/oneapi/mkl/latest/lib/intel64/libmkl_core.so.2 /usr/local/lib/libmkl_core.so.2
+COPY --from=builder /opt/intel/oneapi/mkl/latest/lib/intel64/libmkl_vml_def.so.2 /usr/local/lib/libmkl_vml_def.so.2
+COPY --from=builder /opt/intel/oneapi/mkl/latest/lib/intel64/libmkl_def.so.2 /usr/local/lib/libmkl_def.so.2
+COPY --from=builder /opt/intel/oneapi/mkl/latest/lib/intel64/libmkl_vml_avx2.so.2 /usr/local/lib/libmkl_vml_avx2.so.2
+COPY --from=builder /opt/intel/oneapi/mkl/latest/lib/intel64/libmkl_vml_avx512.so.2 /usr/local/lib/libmkl_vml_avx512.so.2
+COPY --from=builder /opt/intel/oneapi/mkl/latest/lib/intel64/libmkl_avx2.so.2 /usr/local/lib/libmkl_avx2.so.2
+COPY --from=builder /opt/intel/oneapi/mkl/latest/lib/intel64/libmkl_avx512.so.2 /usr/local/lib/libmkl_avx512.so.2
+COPY --from=builder /usr/src/libfakeintel.so /usr/local/libfakeintel.so
+
+COPY --from=builder /usr/src/target/release/text-embeddings-router /usr/local/bin/text-embeddings-router
+
+ENV HF_HUB_USER_AGENT_ORIGIN=aws:sagemaker:cpu:inference:tei
+
+COPY --chmod=775 /huggingface/pytorch/tei/docker/1.9.3/cpu/entrypoint.sh entrypoint.sh
+ENTRYPOINT ["./entrypoint.sh"]
+CMD ["--json-output"]

--- a/huggingface/pytorch/tei/docker/1.9.3/cpu/Dockerfile
+++ b/huggingface/pytorch/tei/docker/1.9.3/cpu/Dockerfile
@@ -61,7 +61,7 @@ RUN --mount=type=secret,id=actions_results_url,env=ACTIONS_RESULTS_URL \
     --mount=type=secret,id=actions_runtime_token,env=ACTIONS_RUNTIME_TOKEN \
     cargo build --release --bin text-embeddings-router --features ort,candle,mkl,static-linking,http --no-default-features && sccache -s
 
-FROM debian:bookworm-slim AS base
+FROM debian:bookworm-slim AS sagemaker
 
 ENV HUGGINGFACE_HUB_CACHE=/opt/ml/model \
     PORT=8080 \

--- a/huggingface/pytorch/tei/docker/1.9.3/cpu/entrypoint.sh
+++ b/huggingface/pytorch/tei/docker/1.9.3/cpu/entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+if [[ -z "${HF_MODEL_ID}" ]]; then
+    echo "HF_MODEL_ID must be set"
+    exit 1
+fi
+export MODEL_ID="${HF_MODEL_ID}"
+
+if [[ -n "${HF_MODEL_REVISION}" ]]; then
+    export REVISION="${HF_MODEL_REVISION}"
+fi
+
+exec text-embeddings-router "$@"

--- a/huggingface/pytorch/tei/docker/1.9.3/cpu/entrypoint.sh
+++ b/huggingface/pytorch/tei/docker/1.9.3/cpu/entrypoint.sh
@@ -10,4 +10,4 @@ if [[ -n "${HF_MODEL_REVISION}" ]]; then
     export REVISION="${HF_MODEL_REVISION}"
 fi
 
-exec text-embeddings-router "$@"
+exec text-embeddings-router --port 8080 --json-output

--- a/huggingface/pytorch/tei/docker/1.9.3/gpu/Dockerfile
+++ b/huggingface/pytorch/tei/docker/1.9.3/gpu/Dockerfile
@@ -130,4 +130,3 @@ ENV HF_HUB_USER_AGENT_ORIGIN=aws:sagemaker:gpu-cuda:inference:tei
 
 COPY --chmod=775 /huggingface/pytorch/tei/docker/1.9.3/gpu/entrypoint.sh entrypoint.sh
 ENTRYPOINT ["./entrypoint.sh"]
-CMD ["--json-output"]

--- a/huggingface/pytorch/tei/docker/1.9.3/gpu/Dockerfile
+++ b/huggingface/pytorch/tei/docker/1.9.3/gpu/Dockerfile
@@ -106,7 +106,7 @@ RUN --mount=type=secret,id=actions_results_url,env=ACTIONS_RESULTS_URL \
 
 RUN mv /usr/src/target/release/text-embeddings-router /usr/src/target/release/text-embeddings-router-120
 
-FROM nvidia/cuda:12.9.1-runtime-ubuntu24.04 AS base
+FROM nvidia/cuda:12.9.1-runtime-ubuntu24.04 AS sagemaker
 
 ENV HUGGINGFACE_HUB_CACHE=/opt/ml/model \
     PORT=8080 \

--- a/huggingface/pytorch/tei/docker/1.9.3/gpu/Dockerfile
+++ b/huggingface/pytorch/tei/docker/1.9.3/gpu/Dockerfile
@@ -1,0 +1,133 @@
+FROM nvidia/cuda:12.9.1-devel-ubuntu24.04 AS base-builder
+
+ENV SCCACHE=0.10.0
+ENV RUSTC_WRAPPER=/usr/local/bin/sccache
+ENV PATH="/root/.cargo/bin:${PATH}"
+# aligned with `cargo-chef` version in `lukemathwalker/cargo-chef:latest-rust-1.92-bookworm`
+ENV CARGO_CHEF=0.1.73
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    curl \
+    libssl-dev \
+    pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+# Donwload and configure sccache
+RUN curl -fsSL https://github.com/mozilla/sccache/releases/download/v$SCCACHE/sccache-v$SCCACHE-x86_64-unknown-linux-musl.tar.gz | tar -xzv --strip-components=1 -C /usr/local/bin sccache-v$SCCACHE-x86_64-unknown-linux-musl/sccache && \
+    chmod +x /usr/local/bin/sccache
+
+COPY rust-toolchain.toml rust-toolchain.toml
+RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
+RUN cargo install cargo-chef --version $CARGO_CHEF --locked
+
+FROM base-builder AS planner
+
+WORKDIR /usr/src
+
+COPY backends backends
+COPY core core
+COPY router router
+COPY Cargo.toml ./
+COPY Cargo.lock ./
+
+RUN cargo chef prepare  --recipe-path recipe.json
+
+FROM base-builder AS builder
+
+# sccache specific variables
+ARG SCCACHE_GHA_ENABLED
+
+# Limit parallelism
+ARG RAYON_NUM_THREADS=4
+ARG CARGO_BUILD_JOBS
+ARG CARGO_BUILD_INCREMENTAL
+
+WORKDIR /usr/src
+
+COPY --from=planner /usr/src/recipe.json recipe.json
+
+RUN --mount=type=secret,id=actions_results_url,env=ACTIONS_RESULTS_URL \
+    --mount=type=secret,id=actions_runtime_token,env=ACTIONS_RUNTIME_TOKEN \
+    cargo chef cook --release --recipe-path recipe.json && sccache -s;
+
+RUN --mount=type=secret,id=actions_results_url,env=ACTIONS_RESULTS_URL \
+    --mount=type=secret,id=actions_runtime_token,env=ACTIONS_RUNTIME_TOKEN \
+    CUDA_COMPUTE_CAP=75 cargo chef cook --release --features candle-cuda-turing --recipe-path recipe.json && sccache -s;
+
+RUN --mount=type=secret,id=actions_results_url,env=ACTIONS_RESULTS_URL \
+    --mount=type=secret,id=actions_runtime_token,env=ACTIONS_RUNTIME_TOKEN \
+    CUDA_COMPUTE_CAP=80 cargo chef cook --release --features candle-cuda --recipe-path recipe.json && sccache -s;
+
+RUN --mount=type=secret,id=actions_results_url,env=ACTIONS_RESULTS_URL \
+    --mount=type=secret,id=actions_runtime_token,env=ACTIONS_RUNTIME_TOKEN \
+    CUDA_COMPUTE_CAP=90 cargo chef cook --release --features candle-cuda --recipe-path recipe.json && sccache -s;
+
+RUN --mount=type=secret,id=actions_results_url,env=ACTIONS_RESULTS_URL \
+    --mount=type=secret,id=actions_runtime_token,env=ACTIONS_RUNTIME_TOKEN \
+    CUDA_COMPUTE_CAP=100 cargo chef cook --release --features candle-cuda --recipe-path recipe.json && sccache -s;
+
+RUN --mount=type=secret,id=actions_results_url,env=ACTIONS_RESULTS_URL \
+    --mount=type=secret,id=actions_runtime_token,env=ACTIONS_RUNTIME_TOKEN \
+    CUDA_COMPUTE_CAP=120 cargo chef cook --release --features candle-cuda --recipe-path recipe.json && sccache -s;
+
+COPY backends backends
+COPY core core
+COPY router router
+COPY Cargo.toml ./
+COPY Cargo.lock ./
+
+RUN --mount=type=secret,id=actions_results_url,env=ACTIONS_RESULTS_URL \
+    --mount=type=secret,id=actions_runtime_token,env=ACTIONS_RUNTIME_TOKEN \
+    CUDA_COMPUTE_CAP=75 cargo build --release --bin text-embeddings-router -F candle-cuda-turing && sccache -s;
+
+RUN mv /usr/src/target/release/text-embeddings-router /usr/src/target/release/text-embeddings-router-75
+
+RUN --mount=type=secret,id=actions_results_url,env=ACTIONS_RESULTS_URL \
+    --mount=type=secret,id=actions_runtime_token,env=ACTIONS_RUNTIME_TOKEN \
+    CUDA_COMPUTE_CAP=80 cargo build --release --bin text-embeddings-router -F candle-cuda && sccache -s;
+
+RUN mv /usr/src/target/release/text-embeddings-router /usr/src/target/release/text-embeddings-router-80
+
+RUN --mount=type=secret,id=actions_results_url,env=ACTIONS_RESULTS_URL \
+    --mount=type=secret,id=actions_runtime_token,env=ACTIONS_RUNTIME_TOKEN \
+    CUDA_COMPUTE_CAP=90 cargo build --release --bin text-embeddings-router -F candle-cuda && sccache -s;
+
+RUN mv /usr/src/target/release/text-embeddings-router /usr/src/target/release/text-embeddings-router-90
+
+RUN --mount=type=secret,id=actions_results_url,env=ACTIONS_RESULTS_URL \
+    --mount=type=secret,id=actions_runtime_token,env=ACTIONS_RUNTIME_TOKEN \
+    CUDA_COMPUTE_CAP=100 cargo build --release --bin text-embeddings-router -F candle-cuda && sccache -s;
+
+RUN mv /usr/src/target/release/text-embeddings-router /usr/src/target/release/text-embeddings-router-100
+
+RUN --mount=type=secret,id=actions_results_url,env=ACTIONS_RESULTS_URL \
+    --mount=type=secret,id=actions_runtime_token,env=ACTIONS_RUNTIME_TOKEN \
+    CUDA_COMPUTE_CAP=120 cargo build --release --bin text-embeddings-router -F candle-cuda && sccache -s;
+
+RUN mv /usr/src/target/release/text-embeddings-router /usr/src/target/release/text-embeddings-router-120
+
+FROM nvidia/cuda:12.9.1-runtime-ubuntu24.04 AS base
+
+ENV HUGGINGFACE_HUB_CACHE=/opt/ml/model \
+    PORT=8080 \
+    USE_FLASH_ATTENTION=True \
+    LD_LIBRARY_PATH="/usr/local/cuda/lib64:${LD_LIBRARY_PATH}"
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    ca-certificates \
+    libssl-dev \
+    curl \
+    cuda-compat-12-9 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /usr/src/target/release/text-embeddings-router-75 /usr/local/bin/text-embeddings-router-75
+COPY --from=builder /usr/src/target/release/text-embeddings-router-80 /usr/local/bin/text-embeddings-router-80
+COPY --from=builder /usr/src/target/release/text-embeddings-router-90 /usr/local/bin/text-embeddings-router-90
+COPY --from=builder /usr/src/target/release/text-embeddings-router-100 /usr/local/bin/text-embeddings-router-100
+COPY --from=builder /usr/src/target/release/text-embeddings-router-120 /usr/local/bin/text-embeddings-router-120
+
+ENV HF_HUB_USER_AGENT_ORIGIN=aws:sagemaker:gpu-cuda:inference:tei
+
+COPY --chmod=775 /huggingface/pytorch/tei/docker/1.9.3/gpu/entrypoint.sh entrypoint.sh
+ENTRYPOINT ["./entrypoint.sh"]
+CMD ["--json-output"]

--- a/huggingface/pytorch/tei/docker/1.9.3/gpu/entrypoint.sh
+++ b/huggingface/pytorch/tei/docker/1.9.3/gpu/entrypoint.sh
@@ -30,15 +30,15 @@ fi
 compute_cap=$(nvidia-smi --query-gpu=compute_cap --format=csv | sed -n '2p' | sed 's/\.//g')
 
 if [ ${compute_cap} -eq 75 ]; then
-    exec text-embeddings-router-75 "$@"
+    exec text-embeddings-router-75 --port 8080 --json-ouput
 elif [ ${compute_cap} -ge 80 -a ${compute_cap} -lt 90 ]; then
-    exec text-embeddings-router-80 "$@"
+    exec text-embeddings-router-80 --port 8080 --json-ouput
 elif [ ${compute_cap} -eq 90 ]; then
-    exec text-embeddings-router-90 "$@"
+    exec text-embeddings-router-90 --port 8080 --json-ouput
 elif [ ${compute_cap} -eq 100 ]; then
-    exec text-embeddings-router-100 "$@"
+    exec text-embeddings-router-100 --port 8080 --json-ouput
 elif [ ${compute_cap} -eq 120 ]; then
-    exec text-embeddings-router-120 "$@"
+    exec text-embeddings-router-120 --port 8080 --json-ouput
 else
     echo "cuda compute cap ${compute_cap} is not supported"
     exit 1

--- a/huggingface/pytorch/tei/docker/1.9.3/gpu/entrypoint.sh
+++ b/huggingface/pytorch/tei/docker/1.9.3/gpu/entrypoint.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+if [[ -z "${HF_MODEL_ID}" ]]; then
+    echo "HF_MODEL_ID must be set"
+    exit 1
+fi
+export MODEL_ID="${HF_MODEL_ID}"
+
+if [[ -n "${HF_MODEL_REVISION}" ]]; then
+    export REVISION="${HF_MODEL_REVISION}"
+fi
+
+if ! command -v nvidia-smi &>/dev/null; then
+    echo "Error: 'nvidia-smi' command not found."
+    exit 1
+fi
+
+# NOTE: When the installed NVIDIA kernel driver is older than the version required
+# by the CUDA compat package (as indicated by the libcuda.so.1 symlink), we need
+# to include the compat directory in `LD_LIBRARY_PATH` to bridge the mismatch.
+if [ -f /usr/local/cuda/compat/libcuda.so.1 ]; then
+    CUDA_COMPAT_MAX_DRIVER_VERSION=$(readlink /usr/local/cuda/compat/libcuda.so.1 | cut -d'.' -f 3-)
+    NVIDIA_DRIVER_VERSION=$(sed -n 's/^NVRM.*Kernel Module *\([0-9.]*\).*$/\1/p' /proc/driver/nvidia/version 2>/dev/null || true)
+    if [ "$NVIDIA_DRIVER_VERSION" != "$CUDA_COMPAT_MAX_DRIVER_VERSION" ] &&
+        [ "$NVIDIA_DRIVER_VERSION" = "$(printf '%s\n' "$NVIDIA_DRIVER_VERSION" "$CUDA_COMPAT_MAX_DRIVER_VERSION" | sort -V | head -n1)" ]; then
+        export LD_LIBRARY_PATH="/usr/local/cuda/compat:${LD_LIBRARY_PATH}"
+    fi
+fi
+
+compute_cap=$(nvidia-smi --query-gpu=compute_cap --format=csv | sed -n '2p' | sed 's/\.//g')
+
+if [ ${compute_cap} -eq 75 ]; then
+    exec text-embeddings-router-75 "$@"
+elif [ ${compute_cap} -ge 80 -a ${compute_cap} -lt 90 ]; then
+    exec text-embeddings-router-80 "$@"
+elif [ ${compute_cap} -eq 90 ]; then
+    exec text-embeddings-router-90 "$@"
+elif [ ${compute_cap} -eq 100 ]; then
+    exec text-embeddings-router-100 "$@"
+elif [ ${compute_cap} -eq 120 ]; then
+    exec text-embeddings-router-120 "$@"
+else
+    echo "cuda compute cap ${compute_cap} is not supported"
+    exit 1
+fi

--- a/huggingface/pytorch/tei/docker/buildspec.yml
+++ b/huggingface/pytorch/tei/docker/buildspec.yml
@@ -23,8 +23,8 @@ phases:
     commands:
       - echo Pre-build started on `date`
       - export PYTHONPATH=$(pwd):$PYTHONPATH
-      
-      # Continue with regular pre-build steps if BUILD_REQUIRED=true 
+
+      # Continue with regular pre-build steps if BUILD_REQUIRED=true
       - |
         echo Setting up Docker buildx.
         docker buildx version

--- a/releases.json
+++ b/releases.json
@@ -110,17 +110,17 @@
             {
                 "device": "gpu",
                 "min_version": "1.2.1",
-                "max_version": "1.8.2",
-                "os_version": "ubuntu22.04",
+                "max_version": "1.9.3",
+                "os_version": "ubuntu24.04",
                 "python_version": "py310",
                 "pytorch_version": "2.0.1",
-                "cuda_version": "cu122"
+                "cuda_version": "cu129"
             },
             {
                 "device": "cpu",
                 "min_version": "1.2.1",
-                "max_version": "1.8.2",
-                "os_version": "ubuntu22.04",
+                "max_version": "1.9.3",
+                "os_version": "ubuntu24.04",
                 "python_version": "py310",
                 "pytorch_version": "2.0.1"
             }

--- a/releases.json
+++ b/releases.json
@@ -154,17 +154,17 @@
         {
             "framework": "TEI",
             "device": "gpu",
-            "version": "1.8.2",
-            "os_version": "ubuntu22.04",
-            "cuda_version": "cu122",
+            "version": "1.9.3",
+            "os_version": "ubuntu24.04",
+            "cuda_version": "cu129",
             "python_version": "py310",
             "pytorch_version": "2.0.1"
         },
         {
             "framework": "TEI",
             "device": "cpu",
-            "version": "1.8.2",
-            "os_version": "ubuntu22.04",
+            "version": "1.9.3",
+            "os_version": "ubuntu24.04",
             "python_version": "py310",
             "pytorch_version": "2.0.1"
         }


### PR DESCRIPTION
*Description of changes:*

This PR adds the Text Embeddings Inference (TEI) v1.9.3 container to be released on both AWS SageMaker and AWS EC2, as per the latest release of the upstream in https://github.com/huggingface/text-embeddings-inference/releases/v1.9.3.

This PR is pretty similar to earlier releases as #141 or #153, with some subtle differences:

- The `entrypoint.sh` no longer lives on https://github.com/huggingface/text-embeddings-inference, but rather in this repository instead
- The `text-embeddings-router` command in the `entrypoint.sh` no longer requires the `--port 8080` flag, as the environment variable `PORT` has been updated to be set to 8080 instead of 80.
- The `entrypoint.sh` for both CPU and NVIDIA GPUs runs the `text-embeddings-router` binary with `exec` so that the signals are captured by the process, as otherwise the running PID of `text-embeddings-router` would be different to 1, hence wouldn't capture the signals 
- Both `Dockerfile` files drop the gRPC layer as it wasn't used but it was being compiled / built nonetheless

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

> [!NOTE]
> By submitting this PR, I disclose that all the code in this PR was written entirely by me, @alvarobartt, without the use of any coding assistants or third-party agentic tools.