### PR TITLE
Fix typo in TEI 1.9.3 GPU entrypoint: --json-ouput -> --json-output

### DIFF
--- a/huggingface/pytorch/tei/docker/1.9.3/gpu/entrypoint.sh
+++ b/huggingface/pytorch/tei/docker/1.9.3/gpu/entrypoint.sh
@@ -30,15 +30,15 @@ fi
 compute_cap=$(nvidia-smi --query-gpu=compute_cap --format=csv | sed -n '2p' | sed 's/\.//g')
 
 if [ ${compute_cap} -eq 75 ]; then
-    exec text-embeddings-router-75 --port 8080 --json-ouput
+    exec text-embeddings-router-75 --port 8080 --json-output
 elif [ ${compute_cap} -ge 80 -a ${compute_cap} -lt 90 ]; then
-    exec text-embeddings-router-80 --port 8080 --json-ouput
+    exec text-embeddings-router-80 --port 8080 --json-output
 elif [ ${compute_cap} -eq 90 ]; then
-    exec text-embeddings-router-90 --port 8080 --json-ouput
+    exec text-embeddings-router-90 --port 8080 --json-output
 elif [ ${compute_cap} -eq 100 ]; then
-    exec text-embeddings-router-100 --port 8080 --json-ouput
+    exec text-embeddings-router-100 --port 8080 --json-output
 elif [ ${compute_cap} -eq 120 ]; then
-    exec text-embeddings-router-120 --port 8080 --json-ouput
+    exec text-embeddings-router-120 --port 8080 --json-output
 else
     echo "cuda compute cap ${compute_cap} is not supported"
     exit 1


### PR DESCRIPTION
## Problem

The TEI 1.9.3 GPU entrypoint (`huggingface/pytorch/tei/docker/1.9.3/gpu/entrypoint.sh`) passes the misspelled flag `--json-ouput` to `text-embeddings-router` on every compute-cap branch. The binary rejects the unknown argument and exits immediately:

```
error: unexpected argument '--json-ouput' found
  tip: a similar argument exists: '--json-output'
```

The container then crash-loops, so any SageMaker endpoint using the GPU image fails the ping health check and never reaches `InService`. This affects all supported GPU compute capabilities (75/80/90/100/120). The CPU 1.9.3 entrypoint is unaffected because it already uses the correct flag.

## Fix

Correct `--json-ouput` -> `--json-output` on all five GPU branches, matching the CPU 1.9.3 entrypoint and prior TEI/TGI versions.

## Testing

Requires an image rebuild and a rerun of the TEI GPU SageMaker integration test (`BAAI/bge-m3` on a GPU instance) to confirm the endpoint reaches `InService`.